### PR TITLE
Implementar casos de uso pendientes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.librepdf</groupId>
+            <artifactId>openpdf</artifactId>
+            <version>1.3.30</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/org/example/controllerweb/AuthController.java
+++ b/src/main/java/org/example/controllerweb/AuthController.java
@@ -151,4 +151,15 @@ public class AuthController {
         return "Model/terminos_y_condiciones";
     }
 
+    @PostMapping("/judoka/eliminar")
+    public String eliminarCuentaJudoka(HttpSession session) {
+        String username = (String) session.getAttribute("username");
+        if (username != null && "judoka".equals(session.getAttribute("tipo"))) {
+            judokaService.eliminarPorUsername(username);
+            session.invalidate();
+            return "redirect:/login?deleted";
+        }
+        return "redirect:/login";
+    }
+
 }

--- a/src/main/java/org/example/controllerweb/ClubWebController.java
+++ b/src/main/java/org/example/controllerweb/ClubWebController.java
@@ -106,6 +106,7 @@ public class ClubWebController {
         nuevoClub.setAnoFundacion(clubForm.getAnoFundacion());
         nuevoClub.setDireccion(clubForm.getDireccion());
         nuevoClub.setHorarios(clubForm.getHorarios());
+        nuevoClub.setDescripcion(clubForm.getDescripcion());
 
         clubService.guardarClub(nuevoClub);
         model.addAttribute("success", "¡Club registrado correctamente! " +
@@ -157,5 +158,42 @@ public class ClubWebController {
         }
 
         return "redirect:/perfil"; // Redirigimos de vuelta al perfil del club.
+    }
+
+    // Permite eliminar un integrante del club
+    @PostMapping("/club/eliminar-judoka/{judokaId}")
+    public String eliminarJudoka(@PathVariable Long judokaId, HttpSession session) {
+        String username = (String) session.getAttribute(USERNAME);
+        if (username == null) {
+            return REDIRECT_LOGIN;
+        }
+
+        Optional<Judoka> judokaOpt = judokaService.buscarPorId(judokaId);
+        Optional<Club> clubOpt = clubService.findByUsername(username);
+
+        if (judokaOpt.isPresent() && clubOpt.isPresent()) {
+            Judoka judoka = judokaOpt.get();
+            Club club = clubOpt.get();
+            if (judoka.getClub() != null && judoka.getClub().getId().equals(club.getId())) {
+                judoka.setClub(null);
+                judokaService.guardarJudoka(judoka);
+            }
+        }
+        return "redirect:/perfil";
+    }
+
+    // Actualiza horarios y descripcion del club
+    @PostMapping("/club/actualizar")
+    public String actualizarClub(@ModelAttribute Club clubActualizado, HttpSession session) {
+        String username = (String) session.getAttribute(USERNAME);
+        if (username == null) {
+            return REDIRECT_LOGIN;
+        }
+        clubService.findByUsername(username).ifPresent(club -> {
+            club.setHorarios(clubActualizado.getHorarios());
+            club.setDescripcion(clubActualizado.getDescripcion());
+            clubService.guardarClub(club);
+        });
+        return "redirect:/perfil";
     }
 }

--- a/src/main/java/org/example/controllerweb/ReporteController.java
+++ b/src/main/java/org/example/controllerweb/ReporteController.java
@@ -1,0 +1,31 @@
+package org.example.controllerweb;
+
+import lombok.RequiredArgsConstructor;
+import org.example.model.user.Judoka;
+import org.example.service.JudokaService;
+import org.example.service.ReporteService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class ReporteController {
+
+    private final ReporteService reporteService;
+    private final JudokaService judokaService;
+
+    @GetMapping("/reporte/combate")
+    public ResponseEntity<byte[]> generarReporte() {
+        List<Judoka> judokas = judokaService.listarJudokas();
+        byte[] pdf = reporteService.generarReporteCombate(judokas);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=report.pdf")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(pdf);
+    }
+}

--- a/src/main/java/org/example/controllerweb/TorneoWebController.java
+++ b/src/main/java/org/example/controllerweb/TorneoWebController.java
@@ -62,4 +62,20 @@ public class TorneoWebController {
 
         return "redirect:/torneos";
     }
+
+    @GetMapping("/torneos/{id}")
+    public String verTorneo(@PathVariable Long id, Model model) {
+        return torneoService.buscarPorId(id)
+                .map(t -> {
+                    model.addAttribute("torneo", t);
+                    return "Torneo/torneo_home";
+                })
+                .orElse("redirect:/torneos");
+    }
+
+    @PostMapping("/torneos/{id}/eliminar-participante/{judokaId}")
+    public String eliminarParticipante(@PathVariable Long id, @PathVariable Long judokaId) {
+        torneoService.eliminarParticipante(id, judokaId);
+        return "redirect:/torneos/" + id;
+    }
 }

--- a/src/main/java/org/example/dto/ClubRegistroDTO.java
+++ b/src/main/java/org/example/dto/ClubRegistroDTO.java
@@ -27,5 +27,7 @@ public class ClubRegistroDTO {
     @NotBlank(message = "Los horarios son obligatorios")
     private String horarios;
 
+    private String descripcion;
+
 
 }

--- a/src/main/java/org/example/model/user/Club.java
+++ b/src/main/java/org/example/model/user/Club.java
@@ -21,6 +21,9 @@ public class Club {
     private String direccion;
     private String horarios;
 
+    @Column(length = 1000)
+    private String descripcion;
+
     @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Judoka> judokas = new ArrayList<>();
 
@@ -55,6 +58,7 @@ public class Club {
                 ", Año Fundación: " + anoFundacion +
                 ", Dirección: " + direccion +
                 ", Horarios: " + horarios +
+                ", Descripción: " + descripcion +
                 ", Judokas inscritos: " + judokas.size();
     }
 }

--- a/src/main/java/org/example/service/JudokaService.java
+++ b/src/main/java/org/example/service/JudokaService.java
@@ -70,6 +70,15 @@ public class JudokaService {
         return judokaRepository.findById(id);
     }
 
+    public void eliminarPorUsername(String username) {
+        judokaRepository.findByUsername(username)
+                .ifPresent(judokaRepository::delete);
+    }
+
+    public void eliminarPorId(Long id) {
+        judokaRepository.deleteById(id);
+    }
+
     // MODIFICADO: Se añade un método de servicio para exponer la nueva consulta del repositorio.
     public List<Judoka> listarJudokasSinClub() {
         return judokaRepository.findByClubIsNull();

--- a/src/main/java/org/example/service/ReporteService.java
+++ b/src/main/java/org/example/service/ReporteService.java
@@ -1,0 +1,43 @@
+package org.example.service;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+import org.example.model.user.Judoka;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+@Service
+public class ReporteService {
+
+    public byte[] generarReporteCombate(List<Judoka> judokas) {
+        Document document = new Document();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            PdfWriter.getInstance(document, baos);
+            document.open();
+            document.add(new Paragraph("Estadisticas de Combate"));
+            PdfPTable table = new PdfPTable(4);
+            table.addCell("Judoka");
+            table.addCell("Victorias");
+            table.addCell("Derrotas");
+            table.addCell("Empates");
+            for (Judoka j : judokas) {
+                table.addCell(j.getNombre() + " " + j.getApellido());
+                table.addCell(String.valueOf(j.getVictorias()));
+                table.addCell(String.valueOf(j.getDerrotas()));
+                table.addCell(String.valueOf(j.getEmpates()));
+            }
+            document.add(table);
+        } catch (DocumentException e) {
+            // ignored
+        } finally {
+            document.close();
+        }
+        return baos.toByteArray();
+    }
+}

--- a/src/main/java/org/example/service/TorneoService.java
+++ b/src/main/java/org/example/service/TorneoService.java
@@ -72,4 +72,12 @@ public class TorneoService {
         torneoRepository.deleteById(id);
     }
 
+    public void eliminarParticipante(Long torneoId, Long judokaId) {
+        torneoRepository.findById(torneoId).ifPresent(t -> {
+            t.getParticipantes().removeIf(j -> j.getId() == judokaId);
+            torneoRepository.save(t);
+        });
+    }
+
+
 }

--- a/src/main/resources/templates/Club/Perfil_Club.html
+++ b/src/main/resources/templates/Club/Perfil_Club.html
@@ -337,9 +337,11 @@
       </tr>
     </table>
     <div class="empty-message">No hay horarios registrados aún.</div>
-    <div class="add-btn">
-      <button title="Agregar Horario">+</button>
-    </div>
+    <form th:action="@{/club/actualizar}" method="post">
+      <input type="text" name="horarios" th:value="${club.horarios}" placeholder="Horarios"/>
+      <textarea name="descripcion" th:text="${club.descripcion}" placeholder="Descripción" rows="3"></textarea>
+      <button type="submit" class="create-btn">Guardar</button>
+    </form>
   </div>
 
   <div class="section">

--- a/src/main/resources/templates/Club/registro_club.html
+++ b/src/main/resources/templates/Club/registro_club.html
@@ -145,6 +145,8 @@
       <input type="text" th:field="*{sensei}" placeholder="Nombre del sensei" required/>
       <input type="text" th:field="*{anoFundacion}" placeholder="Año de fundación" required/>
       <input type="text" th:field="*{direccion}" placeholder="Dirección del club" required/>
+      <input type="text" th:field="*{horarios}" placeholder="Horarios" required/>
+      <textarea th:field="*{descripcion}" placeholder="Descripción" rows="3"></textarea>
       <button type="submit">Registrar Club</button>
     </form>
   </div>

--- a/src/main/resources/templates/Torneo/torneo_home.html
+++ b/src/main/resources/templates/Torneo/torneo_home.html
@@ -261,6 +261,10 @@
         <span class="info-label">Descripción:</span>
         <span class="desc" th:text="${torneo.descripcion}">Torneo anual de judo...</span>
       </div>
+      <div class="info-row" th:if="${torneo.ganador != null}">
+        <span class="info-label">Ganador:</span>
+        <span class="info-value" th:text="${torneo.ganador.nombre}">Ganador</span>
+      </div>
     </div>
     <div class="participants-section">
       <h3>Participantes:</h3>
@@ -268,9 +272,11 @@
         <span style="color:var(--gris-claro)">No hay participantes registrados.</span>
       </div>
       <ul class="participants-list" th:if="${not #lists.isEmpty(torneo.participantes)}">
-        <li th:each="j : ${torneo.participantes}"
-            th:text="${j.nombre + ' ' + j.apellido + ' (' + j.categoria + ')'}">
-          Judoka 1 (Categoría)
+        <li th:each="j : ${torneo.participantes}">
+          <span th:text="${j.nombre + ' ' + j.apellido + ' (' + j.categoria + ')'}"></span>
+          <form th:action="@{/torneos/{id}/eliminar-participante/{jid}(id=${torneo.id},jid=${j.id})}" method="post" style="display:inline">
+            <button type="submit">Eliminar</button>
+          </form>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- add campo **descripcion** en `Club` y DTO de registro
- permitir eliminación de cuenta de judoka
- agregar endpoints para editar club, eliminar integrantes y ver torneos
- añadir generación de reporte PDF de combates
- permitir eliminar participantes de torneo y mostrar ganador
- exponer campos horarios y descripción en vistas HTML

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697ea14004832b8b4504c10a85bcb6